### PR TITLE
PMM-1126 fix promu build

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     cgo: true
 repository:
-    path: github.com/prometheus/node_exporter
+    path: github.com/percona/node_exporter
 build:
     flags: -a -tags 'netgo static_build'
     ldflags: |


### PR DESCRIPTION
STR
```
mkdir /tmp/sfsd
cd /tmp/sfsd
export GOPATH=$(pwd)
git clone https://github.com/percona/node_exporter src/github.com/percona/node_exporter
cd src/github.com/percona/node_exporter
promu build
```
expected result: node_exporter built fine
curent result:
```
can't load package: package github.com/prometheus/node_exporter: cannot find package "github.com/prometheus/node_exporter" in any of:
	/Users/marzhan/.gvm/gos/go1.8/src/github.com/prometheus/node_exporter (from $GOROOT)
	/tmp/sfsd/src/github.com/prometheus/node_exporter (from $GOPATH)
```