### PR TITLE
Get sysfs and procfs data from remote mysql server with I_S.procfs

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -112,6 +112,9 @@ func (n nodeCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect implements the prometheus.Collector interface.
 func (n nodeCollector) Collect(ch chan<- prometheus.Metric) {
 	wg := sync.WaitGroup{}
+
+	ReadProcfsFromMysql()
+
 	wg.Add(len(n.Collectors))
 	for name, c := range n.Collectors {
 		go func(name string, c Collector) {

--- a/collector/mysql_procfs.go
+++ b/collector/mysql_procfs.go
@@ -1,0 +1,98 @@
+package collector
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/prometheus/common/log"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	// mysqlDSN could be "root:secret@tcp(127.0.0.1:3306)".
+	// Disables mysql procfs if DSN is empty.
+	mysqlDSN = kingpin.Flag("collector.mysqlprocfs", "DSN for information_schema.procfs.").String()
+)
+
+// ReadProcfsFromMysql stores proc/sys files received from mysql procfs plugin on a local filesystem.
+func ReadProcfsFromMysql() {
+	if len(*mysqlDSN) == 0 {
+		return
+	}
+
+	db, err := sql.Open("mysql", *mysqlDSN+"/information_schema?charset=utf8")
+	if err != nil {
+		log.Errorf("mysql_procfs collector connection problem: %s", err)
+		return
+	}
+
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Errorf("mysql_procfs db connection close: %s", err)
+		}
+	}()
+
+	rows, err := db.Query("SELECT file, contents FROM procfs")
+	if err != nil {
+		log.Errorf("mysql_procfs collector query error: %s", err)
+		return
+	}
+
+	defer func() {
+		_ = rows.Close()
+		_ = rows.Err() // or modify return value
+	}()
+
+	for rows.Next() {
+		var fileName string
+
+		var contents string
+
+		err = rows.Scan(&fileName, &contents)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				log.Debugf("No /proc /sys files configured on mysql side.")
+			} else {
+				log.Warnln("mysql_procfs collector query error", err)
+			}
+			continue
+		}
+		writeProcfsFile(fileName, contents)
+	}
+}
+
+// writeProcfsFile stores contents to proc/sys file at local fileName.
+func writeProcfsFile(fileName string, contents string) {
+	if strings.HasPrefix(fileName, "/proc") {
+		fileName = procFilePath(strings.TrimPrefix(fileName, "/proc"))
+	} else if strings.HasPrefix(fileName, "/sys") {
+		fileName = sysFilePath(strings.TrimPrefix(fileName, "/sys"))
+	} else {
+		return
+	}
+	if err := os.MkdirAll(path.Dir(fileName), 0750); err != nil {
+		log.Warnln("Couldn't create directory", err)
+		return
+	}
+	file, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		log.Warnln("Couldn't create file", fileName, err)
+		return
+	}
+	defer file.Close()
+	if err = file.Truncate(0); err != nil {
+		log.Warnln("Couldn't truncate file", err)
+		return
+	}
+	if _, err = file.Seek(0, 0); err != nil {
+		log.Warnln("Couldn't seek", err)
+		return
+	}
+	if _, err = file.WriteString(contents); err != nil {
+		log.Warnln("Couldn't write", err)
+		return
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a
+	github.com/go-sql-driver/mysql v1.6.0
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=

--- a/node_exporter.go
+++ b/node_exporter.go
@@ -26,6 +26,8 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
 	"gopkg.in/alecthomas/kingpin.v2"
+	// used by collector/mysql_procfs.go
+	_ "github.com/go-sql-driver/mysql"
 )
 
 // handler wraps an unfiltered http.Handler but uses a filtered handler,


### PR DESCRIPTION
Fetches sysfs and procfs files contents from remote mysql servers via https://github.com/Percona-Lab/procfs and stores these files in -collector.procfs and -collector.sysfs directories before parsing

https://jira.percona.com/browse/PMM-7593