### PR TITLE
PMM-14832 make mount path configurable

### DIFF
--- a/collector/filesystem_linux.go
+++ b/collector/filesystem_linux.go
@@ -43,6 +43,9 @@ var mountTimeout = kingpin.Flag("collector.filesystem.mount-timeout",
 var statWorkerCount = kingpin.Flag("collector.filesystem.stat-workers",
 	"how many stat calls to process simultaneously").
 	Hidden().Default("4").Int()
+var mountInfoPath = kingpin.Flag("collector.filesystem.mount-info-path",
+	"Override path to mounts file. If set, disables the default /proc/1/mounts fallback logic.").
+	Default("").String()
 var stuckMounts = make(map[string]struct{})
 var stuckMountsMtx = &sync.Mutex{}
 
@@ -178,8 +181,13 @@ func stuckMountWatcher(mountPoint string, success chan struct{}, logger log.Logg
 }
 
 func mountPointDetails(logger log.Logger) ([]filesystemLabels, error) {
-	file, err := os.Open(procFilePath("1/mounts"))
-	if errors.Is(err, os.ErrNotExist) {
+	path := procFilePath("1/mounts")
+	if *mountInfoPath != "" {
+		path = *mountInfoPath
+	}
+
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) && *mountInfoPath == "" {
 		// Fallback to `/proc/mounts` if `/proc/1/mounts` is missing due hidepid.
 		level.Debug(logger).Log("msg", "Reading root mounts failed, falling back to system mounts", "err", err)
 		file, err = os.Open(procFilePath("mounts"))

--- a/collector/filesystem_linux_test.go
+++ b/collector/filesystem_linux_test.go
@@ -142,3 +142,32 @@ func TestPathRootfs(t *testing.T) {
 		}
 	}
 }
+
+func TestMountInfoPathOverride(t *testing.T) {
+	// --path.procfs points to fixtures with 25+ mount points,
+	// but --collector.filesystem.mount-info-path overrides to a file with only 1 mount.
+	if _, err := kingpin.CommandLine.Parse([]string{
+		"--path.procfs", "./fixtures/proc",
+		"--collector.filesystem.mount-info-path", "./fixtures_hidepid/proc/mounts",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]string{
+		"/": "",
+	}
+
+	filesystems, err := mountPointDetails(log.NewNopLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(filesystems) != len(expected) {
+		t.Errorf("expected %d mounts, got %d", len(expected), len(filesystems))
+	}
+	for _, fs := range filesystems {
+		if _, ok := expected[fs.mountPoint]; !ok {
+			t.Errorf("Got unexpected %s", fs.mountPoint)
+		}
+	}
+}


### PR DESCRIPTION
By design, node_exporter first tries to read /proc/1/mounts and only falls back to /proc/self/mounts if /proc/1/mounts is not accessible.

However, with shareProcessNamespace enabled (like we have in postgres operator):

PID 1 inside the Pod belongs to the /pause container.

The /pause container runs in a restricted mount namespace.

As a result, /proc/1/mounts only reflects the limited mount view of the /pause container.

It does not expose the full set of actual node mounts.

Because /proc/1/mounts is technically accessible, node_exporter does not fall back to /proc/self/mounts.

This leads to incomplete or incorrect mount metrics being collected by node_exporter