### PR TITLE
Bump Go version from 1.25.5 to 1.25.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Node exporter
 
 [![CircleCI](https://circleci.com/gh/prometheus/node_exporter/tree/master.svg?style=shield)][circleci]
-[![Buildkite status](https://badge.buildkite.com/94a0c1fb00b1f46883219c256efe9ce01d63b6505f3a942f9b.svg)](https://buildkite.com/prometheus/node-exporter)
 [![Docker Repository on Quay](https://quay.io/repository/prometheus/node-exporter/status)][quay]
 [![Docker Pulls](https://img.shields.io/docker/pulls/prom/node-exporter.svg?maxAge=604800)][hub]
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus/node_exporter)][goreportcard]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/node_exporter
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
This pull request includes two minor updates: one to the documentation and one to the project configuration. The most important changes are listed below.

Project configuration update:

* Updated the Go version in `go.mod` from `1.25.5` to `1.25.8`, ensuring compatibility with the latest Go features and bug fixes.

Documentation update:

* Removed the Buildkite status badge from `README.md` to clean up the project’s status indicators.